### PR TITLE
auto-sync opcode & operand encoding info generation

### DIFF
--- a/llvm/include/llvm/Support/Compiler.h
+++ b/llvm/include/llvm/Support/Compiler.h
@@ -139,7 +139,7 @@
 #define LLVM_ATTRIBUTE_USED
 #endif
 
-#if defined(__clang__)
+#if defined(__clang__) && !defined(__INTELLISENSE__)
 #define LLVM_DEPRECATED(MSG, FIX) __attribute__((deprecated(MSG, FIX)))
 #else
 #define LLVM_DEPRECATED(MSG, FIX) [[deprecated(MSG)]]

--- a/llvm/utils/TableGen/PrinterCapstone.cpp
+++ b/llvm/utils/TableGen/PrinterCapstone.cpp
@@ -2537,7 +2537,7 @@ std::string getArchSupplInfo(StringRef const &TargetName,
                              raw_string_ostream &PPCFormatEnum) {
   if (TargetName == "PPC")
     return getArchSupplInfoPPC(TargetName, CGI, PPCFormatEnum);
-  return "{ 0 }";
+  return "{{ 0 }}";
 }
 
 Record *argInitOpToRecord(Init *ArgInit) {


### PR DESCRIPTION
This is the modified llvm-capstone version that I used to generate the encoding info of both opcode and operands of an instruction for the **ARM** architecture. However this version could also be used to generate the required tables for the rest of the auto-sync archs. My modifications are quite simple. I only added two new functions, one called `getCSOperandEncoding` and the other `getCSOpcodeEncoding`. The former is being used on `printInsnOpMapEntry` (so the operand encoding info goes to the InsnMapOp.inc file) while the latter on `printInsnMapEntry`.