### PR TITLE
Little ARM and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ Please note that within LLVM we speak of a `Target` if we refer to an architectu
 
 The TableGen emitter backends are located in `llvm/utils/TableGen/`.
 
-The target definition files (`.td`), which define the
-instructions, operands, features etc., can be
-found in `llvm/lib/Target/<ARCH>/`.
+The target definition files (`.td`) define the
+instructions, operands, features and other things. This is the source of all our information.
+If something is wrongly defined there, it will be wrong in the generated files.
+You can find the `td` files in `llvm/lib/Target/<ARCH>/`.
 
 ### Code generation overview
 
@@ -69,14 +70,13 @@ We use the following emitter backends
 | InstrInfoEmitter | Tables with instruction information (instruction enum, instr. operand information...) | |
 | RegisterInfoEmitter | Tables with register information (register enum, register type info...) | |
 | SubtargetEmitter | Table about the target features. | |
-| SearchableTablesEmitter | Usually used to generate tables and decoding functions for system registers. | **1.** Not all targets use this. |
-| | | **2.** Backend can't access the target name. Wherever the target name is needed `__ARCH__` or `##ARCH##` is printed and later replaced. |
+| SearchableTablesEmitter | Usually used to generate tables and decoding functions for system operands. | **1.** Not all targets use this. |
 
 ## Developer notes
 
 - If you find C++ code within the generated files you need to extend `PrinterCapstone::translateToC()`.
 If this still doesn't fix the problem, the code snipped wasn't passed through `translateToC()` before emitting.
-So you need to figure out where this specific code snipped is printed and add `translateToC()`.
+So you need to figure out where this specific code snipped is printed and pass it to `translateToC()`.
 
 - If the mapping files miss operand types or access information, then the `.td` files are incomplete (happens surprisingly often).
 You need to search for the instruction or operands with missing or incorrect values and fix them.
@@ -86,8 +86,8 @@ You need to search for the instruction or operands with missing or incorrect val
       - Memory: The "mayLoad" or "mayStore" variable is not set for the instruction.
 
     Operand type is invalid:
-      - The "OperandType" variable is unset for this operand type.
+      - The "OperandType" variable is unset for this operand.
   ```
 
-- If certain target features (e.g. architecture extensions) were removed from LLVM or you want to add your own,
+- If certain target features (e.g. architecture extensions) were removed from upstream LLVM or you want to add your own,
 checkout [DeprecatedFeatures.md](DeprecatedFeatures.md).

--- a/llvm/lib/Target/ARM/ARMInstrFormats.td
+++ b/llvm/lib/Target/ARM/ARMInstrFormats.td
@@ -1405,8 +1405,8 @@ class ThumbXI<dag oops, dag iops, AddrMode am, int sz,
 }
 
 class T2I<dag oops, dag iops, InstrItinClass itin,
-          string opc, string asm, list<dag> pattern, AddrMode am = AddrModeNone>
-  : Thumb2I<oops, iops, am, 4, itin, opc, asm, "", pattern>;
+          string opc, string asm, list<dag> pattern, AddrMode am = AddrModeNone, string constraints = "">
+  : Thumb2I<oops, iops, am, 4, itin, opc, asm, constraints, pattern>;
 class T2Ii12<dag oops, dag iops, InstrItinClass itin,
              string opc, string asm, list<dag> pattern>
   : Thumb2I<oops, iops, AddrModeT2_i12, 4, itin, opc, asm, "",pattern>;

--- a/llvm/lib/Target/ARM/ARMInstrInfo.td
+++ b/llvm/lib/Target/ARM/ARMInstrInfo.td
@@ -5437,17 +5437,17 @@ def CDP2 : ABXI<0b1110, (outs), (ins p_imm:$cop, imm0_15:$opc1,
 }
 
 class ACI<dag oops, dag iops, string opc, string asm,
-            list<dag> pattern, IndexMode im = IndexModeNone,
+            list<dag> pattern, string cstrs = "", IndexMode im = IndexModeNone,
             AddrMode am = AddrModeNone>
   : I<oops, iops, am, 4, im, BrFrm, NoItinerary,
-      opc, asm, "", pattern> {
+      opc, asm, cstrs, pattern> {
   let Inst{27-25} = 0b110;
 }
 class ACInoP<dag oops, dag iops, string opc, string asm,
-          list<dag> pattern, IndexMode im = IndexModeNone,
+          list<dag> pattern, string constraints = "", IndexMode im = IndexModeNone,
           AddrMode am = AddrModeNone>
   : InoP<oops, iops, am, 4, im, BrFrm, NoItinerary,
-         opc, asm, "", pattern> {
+         opc, asm, constraints, pattern> {
   let Inst{31-28} = 0b1111;
   let Inst{27-25} = 0b110;
 }
@@ -5455,7 +5455,7 @@ class ACInoP<dag oops, dag iops, string opc, string asm,
 let DecoderNamespace = "CoProc" in {
 multiclass LdStCop<bit load, bit Dbit, string asm, list<dag> pattern> {
   def _OFFSET : ACI<(outs), (ins p_imm:$cop, c_imm:$CRd, addrmode5:$addr),
-                    asm, "\t$cop, $CRd, $addr", pattern, IndexModeNone,
+                    asm, "\t$cop, $CRd, $addr", pattern, "", IndexModeNone,
                     AddrMode5> {
     bits<13> addr;
     bits<4> cop;
@@ -5471,8 +5471,8 @@ multiclass LdStCop<bit load, bit Dbit, string asm, list<dag> pattern> {
     let Inst{7-0} = addr{7-0};
     let DecoderMethod = "DecodeCopMemInstruction";
   }
-  def _PRE : ACI<(outs), (ins p_imm:$cop, c_imm:$CRd, addrmode5_pre:$addr),
-                 asm, "\t$cop, $CRd, $addr!", [], IndexModePre> {
+  def _PRE : ACI<(outs GPR:$Rn_wb), (ins p_imm:$cop, c_imm:$CRd, addrmode5_pre:$addr),
+                 asm, "\t$cop, $CRd, $addr!", [], "$addr.base = $Rn_wb", IndexModePre> {
     bits<13> addr;
     bits<4> cop;
     bits<4> CRd;
@@ -5489,7 +5489,7 @@ multiclass LdStCop<bit load, bit Dbit, string asm, list<dag> pattern> {
   }
   def _POST: ACI<(outs), (ins p_imm:$cop, c_imm:$CRd, addr_offset_none:$addr,
                               postidx_imm8s4:$offset),
-                 asm, "\t$cop, $CRd, $addr, $offset", [], IndexModePost> {
+                 asm, "\t$cop, $CRd, $addr, $offset", [], "", IndexModePost> {
     bits<9> offset;
     bits<4> addr;
     bits<4> cop;
@@ -5527,7 +5527,7 @@ multiclass LdStCop<bit load, bit Dbit, string asm, list<dag> pattern> {
 }
 multiclass LdSt2Cop<bit load, bit Dbit, string asm, list<dag> pattern> {
   def _OFFSET : ACInoP<(outs), (ins p_imm:$cop, c_imm:$CRd, addrmode5:$addr),
-                       asm, "\t$cop, $CRd, $addr", pattern, IndexModeNone,
+                       asm, "\t$cop, $CRd, $addr", pattern, "", IndexModeNone,
                        AddrMode5> {
     bits<13> addr;
     bits<4> cop;
@@ -5543,8 +5543,8 @@ multiclass LdSt2Cop<bit load, bit Dbit, string asm, list<dag> pattern> {
     let Inst{7-0} = addr{7-0};
     let DecoderMethod = "DecodeCopMemInstruction";
   }
-  def _PRE : ACInoP<(outs), (ins p_imm:$cop, c_imm:$CRd, addrmode5_pre:$addr),
-                    asm, "\t$cop, $CRd, $addr!", [], IndexModePre> {
+  def _PRE : ACInoP<(outs GPR:$Rn_wb), (ins p_imm:$cop, c_imm:$CRd, addrmode5_pre:$addr),
+                    asm, "\t$cop, $CRd, $addr!", [], "$addr.base = $Rn_wb", IndexModePre> {
     bits<13> addr;
     bits<4> cop;
     bits<4> CRd;
@@ -5561,7 +5561,7 @@ multiclass LdSt2Cop<bit load, bit Dbit, string asm, list<dag> pattern> {
   }
   def _POST: ACInoP<(outs), (ins p_imm:$cop, c_imm:$CRd, addr_offset_none:$addr,
                                  postidx_imm8s4:$offset),
-                 asm, "\t$cop, $CRd, $addr, $offset", [], IndexModePost> {
+                 asm, "\t$cop, $CRd, $addr, $offset", [], "", IndexModePost> {
     bits<9> offset;
     bits<4> addr;
     bits<4> cop;

--- a/llvm/lib/Target/ARM/ARMInstrThumb2.td
+++ b/llvm/lib/Target/ARM/ARMInstrThumb2.td
@@ -4317,8 +4317,8 @@ def t2ABS : PseudoInst<(outs rGPR:$dst), (ins rGPR:$src),
 // Coprocessor load/store -- for disassembly only
 //
 class T2CI<bits<4> op31_28, dag oops, dag iops, string opc, string asm,
-           list<dag> pattern, AddrMode am = AddrModeNone>
-  : T2I<oops, iops, NoItinerary, opc, asm, pattern, am> {
+           list<dag> pattern, AddrMode am = AddrModeNone, string constraints = "">
+  : T2I<oops, iops, NoItinerary, opc, asm, pattern, am, constraints> {
   let Inst{31-28} = op31_28;
   let Inst{27-25} = 0b110;
 }
@@ -4342,8 +4342,8 @@ multiclass t2LdStCop<bits<4> op31_28, bit load, bit Dbit, string asm, list<dag> 
     let DecoderMethod = "DecodeCopMemInstruction";
   }
   def _PRE : T2CI<op31_28,
-                  (outs), (ins p_imm:$cop, c_imm:$CRd, addrmode5_pre:$addr),
-                  asm, "\t$cop, $CRd, $addr!", []> {
+                  (outs GPR:$Rn_wb), (ins p_imm:$cop, c_imm:$CRd, addrmode5_pre:$addr),
+                  asm, "\t$cop, $CRd, $addr!", [], AddrMode5, "$addr.base = $Rn_wb"> {
     bits<13> addr;
     bits<4> cop;
     bits<4> CRd;

--- a/llvm/lib/Target/ARM/Disassembler/ARMDisassembler.cpp
+++ b/llvm/lib/Target/ARM/Disassembler/ARMDisassembler.cpp
@@ -1862,12 +1862,17 @@ static DecodeStatus DecodeCopMemInstruction(MCInst &Inst, unsigned Insn,
                                             const MCDisassembler *Decoder) {
   DecodeStatus S = MCDisassembler::Success;
 
+  unsigned P = fieldFromInstruction_4(Insn, 24, 1);
+  unsigned W = fieldFromInstruction_4(Insn, 21, 1);
   unsigned pred = fieldFromInstruction(Insn, 28, 4);
   unsigned CRd = fieldFromInstruction(Insn, 12, 4);
   unsigned coproc = fieldFromInstruction(Insn, 8, 4);
   unsigned imm = fieldFromInstruction(Insn, 0, 8);
   unsigned Rn = fieldFromInstruction(Insn, 16, 4);
   unsigned U = fieldFromInstruction(Insn, 23, 1);
+  // Pre-Indexed implies writeback to Rn
+  bool IsPreIndexed = (P == 1) && (W == 1);
+
   const FeatureBitset &featureBits =
     ((const MCDisassembler*)Decoder)->getSubtargetInfo().getFeatureBits();
 
@@ -1942,6 +1947,10 @@ static DecodeStatus DecodeCopMemInstruction(MCInst &Inst, unsigned Insn,
 
   if (featureBits[ARM::HasV8Ops] && (coproc != 14))
     return MCDisassembler::Fail;
+
+  if (IsPreIndexed)
+    // Dummy operand for Rn_wb.
+    MCOperand_CreateImm0(Inst, (0));
 
   Inst.addOperand(MCOperand::createImm(coproc));
   Inst.addOperand(MCOperand::createImm(CRd));

--- a/llvm/utils/TableGen/PrinterCapstone.cpp
+++ b/llvm/utils/TableGen/PrinterCapstone.cpp
@@ -1718,8 +1718,7 @@ void PrinterCapstone::asmWriterEmitPrintAliasInstrBody(
   OS << "  unsigned I = 0;\n";
   OS << "  while (AsmString[I] != ' ' && AsmString[I] != '\\t' &&\n";
   OS << "         AsmString[I] != '$' && AsmString[I] != '\\0')\n";
-  OS << "    ++I;\n";
-  OS << "  SStream_concat1(OS, '\\t');\n"
+  OS << "    ++I;\n"
      << "  char *substr = malloc(I+1);\n"
      << "  memcpy(substr, AsmString, I);\n"
      << "  substr[I] = '\\0';\n"
@@ -1728,7 +1727,6 @@ void PrinterCapstone::asmWriterEmitPrintAliasInstrBody(
 
   OS << "  if (AsmString[I] != '\\0') {\n";
   OS << "    if (AsmString[I] == ' ' || AsmString[I] == '\\t') {\n";
-  OS << "      SStream_concat1(OS, '\\t');\n";
   OS << "      ++I;\n";
   OS << "    }\n";
   OS << "    do {\n";


### PR DESCRIPTION
- Fixes ARM syntax (remove the tab before alias mnemonics)
- Updates the README
  - remove invalid info about the SearchableTable backend
  - Simplify the grammar/word choice here and there.