### PR TITLE
Introducing new updates for operand encoding generation

### DIFF
--- a/llvm/lib/Target/ARM/ARMInstrFormats.td
+++ b/llvm/lib/Target/ARM/ARMInstrFormats.td
@@ -1323,8 +1323,8 @@ class T1pILdStEncode<bits<3> opcode, dag oops, dag iops, AddrMode am,
     T1LoadStore<0b0101, opcode> {
   bits<3> Rt;
   bits<8> addr;
-  let Inst{8-6} = addr{5-3};    // Rm
-  let Inst{5-3} = addr{2-0};    // Rn
+  let Inst{8-6} = addr{2-0};   // Rm
+  let Inst{5-3} = addr{5-3};   // Rn
   let Inst{2-0} = Rt;
 }
 class T1pILdStEncodeImm<bits<4> opA, bit opB, dag oops, dag iops, AddrMode am,
@@ -1334,8 +1334,8 @@ class T1pILdStEncodeImm<bits<4> opA, bit opB, dag oops, dag iops, AddrMode am,
     T1LoadStore<opA, {opB,?,?}> {
   bits<3> Rt;
   bits<8> addr;
-  let Inst{10-6} = addr{7-3};   // imm5
-  let Inst{5-3}  = addr{2-0};   // Rn
+  let Inst{10-6} = addr{4-0};   // imm5
+  let Inst{5-3}  = addr{7-5};   // Rn
   let Inst{2-0}  = Rt;
 }
 

--- a/llvm/lib/Target/ARM/ARMInstrThumb2.td
+++ b/llvm/lib/Target/ARM/ARMInstrThumb2.td
@@ -1249,13 +1249,13 @@ multiclass T2I_ld<bit signed, bits<2> opcod, string opc,
     let Inst{24} = signed;
     let Inst{22-21} = opcod;
     let Inst{20} = 1; // load
-    let Inst{19-16} = 0b1111; // Rn
 
     bits<4> Rt;
     let Inst{15-12} = Rt{3-0};
 
-    bits<13> addr;
-    let Inst{23} = addr{12}; // add = (U == '1')
+    bits<17> addr;
+    let Inst{23} = addr{16}; // add = (U == '1')
+    let Inst{19-16} = addr{15-12}; // Rn
     let Inst{11-0}  = addr{11-0};
 
     let DecoderMethod = "DecodeT2LoadLabel";
@@ -1945,11 +1945,11 @@ class T2Iplpci<bits<1> inst, string opc> : T2Ipc<(outs), (ins t2ldrlabel:$addr),
   let Inst{31-25} = 0b1111100;
   let Inst{24} = inst;
   let Inst{22-20} = 0b001;
-  let Inst{19-16} = 0b1111;
   let Inst{15-12} = 0b1111;
 
-  bits<13> addr;
-  let Inst{23}   = addr{12};   // add = (U == '1')
+  bits<17> addr;
+  let Inst{23}   = addr{16};   // add = (U == '1')
+  let Inst{19-16} = addr{15-12}; // pc
   let Inst{11-0} = addr{11-0}; // imm12
 
   let DecoderMethod = "DecodeT2LoadLabel";

--- a/llvm/utils/TableGen/PrinterCapstone.cpp
+++ b/llvm/utils/TableGen/PrinterCapstone.cpp
@@ -3058,8 +3058,6 @@ void addComplexOperand(
     std::map<std::string, std::vector<Record *>> const InsnPatternMap) {
   DagInit *SubOps = ComplexOp->getValueAsDag("MIOperandInfo");
 
-  std::string const &ComplOperandType = getPrimaryCSOperandType(ComplexOp);
-
   unsigned E = SubOps->getNumArgs();
   for (unsigned I = 0; I != E; ++I) {
     Init *ArgInit = SubOps->getArg(I);


### PR DESCRIPTION
The changes are the following:

- `getCSOperandEncoding` is now a variadic template (needed to combine the encodings of sub-operands to form the full complex operand)
- The above change was used to fix hopefully all post indexed ldr/str instructions (the issue was that LLVM treats base + offset as seperate operands while capstone as one, so I combined the encodings)
- Combines Rn & Rm operands for vld/vst instructions since capstone also treats them as one
- All of the indexes generate should hopefully be based on ISA now
- Made a new function specific for ARM encoding outputs to cover some exceptions (including ldr/str/vld/vst mentioned above)

Let me know if there are any issues