### PR TITLE
Fix Xtensa reachable assert.

### DIFF
--- a/llvm/lib/Target/Xtensa/Disassembler/XtensaDisassembler.cpp
+++ b/llvm/lib/Target/Xtensa/Disassembler/XtensaDisassembler.cpp
@@ -157,8 +157,8 @@ static DecodeStatus decodeImm8Operand(MCInst &Inst, uint64_t Imm,
 static DecodeStatus decodeImm8_sh8Operand(MCInst &Inst, uint64_t Imm,
                                           int64_t Address,
                                           const void *Decoder) {
-  assert(isUInt<8>(Imm) && "Invalid immediate");
-  Inst.addOperand(MCOperand::createImm(SignExtend64<16>(Imm << 8)));
+  assert(isUInt<16>(Imm) && "Invalid immediate");
+  Inst.addOperand(MCOperand::createImm(SignExtend64<16>(Imm)));
   return MCDisassembler::Success;
 }
 


### PR DESCRIPTION
The immediate given to decodeImm8_sh8Operand has been already shifted. Checking if it is an 8bit value fails therefore.

`decodeImm8_sh8Operand` gets called from `XtensaGenDisassemblerTables.inc` like this:
```cpp
...
    if (!Check(S, DecodeARRegisterClass(MI, tmp, Address, Decoder))) { return MCDisassembler::Fail; }
    tmp = fieldFromInstruction(insn, 16, 8) << 8;
    if (!Check(S, decodeImm8_sh8Operand(MI, tmp, Address, Decoder))) { return MCDisassembler::Fail; }
    return S;
...
```