### PR TITLE
Add ARC Patterns

### DIFF
--- a/llvm/utils/TableGen/PrinterCapstone.cpp
+++ b/llvm/utils/TableGen/PrinterCapstone.cpp
@@ -2655,6 +2655,7 @@ normalizedMnemonic(StringRef const &Mn, const bool Upper = true,
     {"[-]", "m"},
     {"[/]", "s"},
     {"[{}]", "_"},
+    {"[#]", "h"},
   };
 
   auto Mnemonic = Upper ? Mn.upper() : Mn.str();
@@ -2683,6 +2684,7 @@ static inline std::string
 getNormalMnemonic(StringRef TargetName, StringRef Mnemonic,
                   const bool Upper = true, const bool ReplaceDot = true) {
   StringRef RemovePattern = TargetName.equals_insensitive("ARM") ? "[{}]" : "";
+  RemovePattern = TargetName.equals_insensitive("ARC") ? "[.]$" : "";
   return normalizedMnemonic(Mnemonic, Upper, ReplaceDot, RemovePattern);
 }
 


### PR DESCRIPTION
This PR adds removing of the last dot in ARC instruction names and replacing of "#" char to Capstone Printer