### PR TITLE
Add tricore tc1.8 instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ pythonenv*
 /clang/utils/analyzer/projects/*/RefScanBuildResults
 # automodapi puts generated documentation files here.
 /lldb/docs/python_api/
+output_tmp/

--- a/llvm/lib/Target/TriCore/TriCore.td
+++ b/llvm/lib/Target/TriCore/TriCore.td
@@ -16,6 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 include "llvm/Target/Target.td"
+include "llvm/TableGen/SearchableTable.td"
 
 //===----------------------------------------------------------------------===//
 // Descriptions
@@ -44,6 +45,9 @@ def HasV161Ops   : SubtargetFeature<"v1.6.1", "HasV161Ops", "true",
 def HasV162Ops   : SubtargetFeature<"v1.6.2", "HasV162Ops", "true",
 								   "Support TriCore v1.6.2 instructions",
 								   []>;
+def HasV180Ops   : SubtargetFeature<"v1.8.0", "HasV180Ops", "true",
+								   "Support TriCore v1.8.0 instructions",
+								   []>;
 
 def HasV110     : Predicate<"HasV120Ops()">, AssemblerPredicate<(all_of HasV110Ops), "v1.1">;
 def HasV120     : Predicate<"HasV120Ops()">, AssemblerPredicate<(all_of HasV120Ops), "v1.2">;
@@ -52,19 +56,22 @@ def HasV131     : Predicate<"HasV131Ops()">, AssemblerPredicate<(all_of HasV131O
 def HasV160     : Predicate<"HasV160Ops()">, AssemblerPredicate<(all_of HasV160Ops), "v1.6">;
 def HasV161     : Predicate<"HasV161Ops()">, AssemblerPredicate<(all_of HasV161Ops), "v1.6.1">;
 def HasV162     : Predicate<"HasV162Ops()">, AssemblerPredicate<(all_of HasV162Ops), "v1.6.2">;
+def HasV180     : Predicate<"HasV180Ops()">, AssemblerPredicate<(all_of HasV180Ops), "v1.8.0">;
 
-def HasV120_UP  : Predicate<"HasV120Ops() || HasV130Ops() || HasV131Ops() || HasV160Ops() || HasV161Ops() || HasV162Ops()">
-				, AssemblerPredicate<(any_of HasV120Ops, HasV130Ops, HasV131Ops, HasV160Ops, HasV161Ops, HasV162Ops), "v120up">;
-def HasV130_UP  : Predicate<"HasV130Ops() || HasV131Ops() || HasV160Ops() || HasV161Ops() || HasV162Ops()">
-				, AssemblerPredicate<(any_of HasV130Ops, HasV131Ops, HasV160Ops, HasV161Ops, HasV162Ops), "v130up">;
-def HasV131_UP  : Predicate<"HasV131Ops() || HasV160Ops() || HasV161Ops() || HasV162Ops()">
-				, AssemblerPredicate<(any_of HasV131Ops, HasV160Ops, HasV161Ops, HasV162Ops), "v131up">;
-def HasV160_UP  : Predicate<"HasV160Ops() || HasV161Ops() || HasV162Ops()">
-				, AssemblerPredicate<(any_of HasV160Ops, HasV161Ops, HasV162Ops), "v160up">;
-def HasV161_UP  : Predicate<"HasV161Ops() || HasV162Ops()">
-				, AssemblerPredicate<(any_of HasV161Ops, HasV162Ops), "v161up">;
-def HasV162_UP  : Predicate<"HasV162Ops()">
-				, AssemblerPredicate<(any_of HasV162Ops), "v162up">;
+def HasV120_UP  : Predicate<"HasV120Ops() || HasV130Ops() || HasV131Ops() || HasV160Ops() || HasV161Ops() || HasV162Ops() || HasV180Ops()">
+				, AssemblerPredicate<(any_of HasV120Ops, HasV130Ops, HasV131Ops, HasV160Ops, HasV161Ops, HasV162Ops, HasV180Ops), "v120up">;
+def HasV130_UP  : Predicate<"HasV130Ops() || HasV131Ops() || HasV160Ops() || HasV161Ops() || HasV162Ops() || HasV180Ops()">
+				, AssemblerPredicate<(any_of HasV130Ops, HasV131Ops, HasV160Ops, HasV161Ops, HasV162Ops, HasV180Ops), "v130up">;
+def HasV131_UP  : Predicate<"HasV131Ops() || HasV160Ops() || HasV161Ops() || HasV162Ops() || HasV180Ops()">
+				, AssemblerPredicate<(any_of HasV131Ops, HasV160Ops, HasV161Ops, HasV162Ops, HasV180Ops), "v131up">;
+def HasV160_UP  : Predicate<"HasV160Ops() || HasV161Ops() || HasV162Ops() || HasV180Ops()">
+				, AssemblerPredicate<(any_of HasV160Ops, HasV161Ops, HasV162Ops, HasV180Ops), "v160up">;
+def HasV161_UP  : Predicate<"HasV161Ops() || HasV162Ops() || HasV180Ops()">
+				, AssemblerPredicate<(any_of HasV161Ops, HasV162Ops, HasV180Ops), "v161up">;
+def HasV162_UP  : Predicate<"HasV162Ops() || HasV180Ops()">
+				, AssemblerPredicate<(any_of HasV162Ops, HasV180Ops), "v162up">;
+def HasV180_UP  : Predicate<"HasV162Ops()">
+				, AssemblerPredicate<(any_of HasV180Ops), "v180up">;
 
 def HasV120_DN : Predicate<"HasV120Ops() || HasV110Ops()">,
 				AssemblerPredicate<(any_of HasV120Ops, HasV110Ops), "v120dn">;
@@ -78,6 +85,8 @@ def HasV161_DN : Predicate<"HasV161Ops() || HasV160Ops() || HasV131Ops() || HasV
 				AssemblerPredicate<(any_of HasV161Ops, HasV160Ops, HasV131Ops, HasV130Ops, HasV120Ops, HasV110Ops), "v161dn">;
 def HasV162_DN : Predicate<"HasV162Ops() || HasV161Ops() || HasV160Ops() || HasV131Ops() || HasV130Ops() || HasV120Ops() || HasV110Ops()">,
 				AssemblerPredicate<(any_of HasV162Ops, HasV161Ops, HasV160Ops, HasV131Ops, HasV130Ops, HasV120Ops, HasV110Ops), "v162dn">;
+def HasV180_DN : Predicate<"HasV180Ops() || HasV162Ops() || HasV161Ops() || HasV160Ops() || HasV131Ops() || HasV130Ops() || HasV120Ops() || HasV110Ops()">,
+				AssemblerPredicate<(any_of HasV180Ops, HasV162Ops, HasV161Ops, HasV160Ops, HasV131Ops, HasV130Ops, HasV120Ops, HasV110Ops), "v162dn">;
 
 
 class Architecture<string fname, string aname, list<SubtargetFeature> features = []>
@@ -95,6 +104,7 @@ def TRICORE_V1_3_1  : Architecture<"tricore-V1.3.1",  "TRICOREv131", [HasV131Ops
 def TRICORE_V1_6    : Architecture<"tricore-V1.6",    "TRICOREv160", [HasV160Ops]>;
 def TRICORE_V1_6_1  : Architecture<"tricore-V1.6.1",  "TRICOREv161", [HasV161Ops]>;
 def TRICORE_V1_6_2  : Architecture<"tricore-V1.6.2",  "TRICOREv162", [HasV162Ops]>;
+def TRICORE_V1_8_0  : Architecture<"tricore-V1.8.0",  "TRICOREv162", [HasV180Ops]>;
 def TRICORE_PCP     : Architecture<"tricore-PCP",     "TRICOREpcp">;
 def TRICORE_PCP2    : Architecture<"tricore-PCP2",    "TRICOREpcp2">;
 
@@ -114,6 +124,7 @@ def : ProcNoItin<"tc1797",  [TRICORE_V1_3_1]>;
 def : ProcNoItin<"tc27x",   [TRICORE_V1_6_1]>;
 def : ProcNoItin<"tc161",   [TRICORE_V1_6_1]>;
 def : ProcNoItin<"tc162",   [TRICORE_V1_6_2]>;
+def : ProcNoItin<"tc180",   [TRICORE_V1_8_0]>;
 def : ProcNoItin<"tc16",    [TRICORE_V1_6]>;
 def : ProcNoItin<"tc131",   [TRICORE_V1_3_1]>;
 def : ProcNoItin<"tc13",    [TRICORE_V1_3]>;

--- a/llvm/lib/Target/TriCore/TriCoreInstrFormats.td
+++ b/llvm/lib/Target/TriCore/TriCoreInstrFormats.td
@@ -30,7 +30,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-class InstTriCore<dag outs, dag ins, string asmstr, list<dag> pattern>
+class I<dag outs, dag ins, string asmstr, list<dag> pattern>
     : Instruction {
 
   let Namespace = "TriCore";
@@ -43,7 +43,7 @@ class InstTriCore<dag outs, dag ins, string asmstr, list<dag> pattern>
 
 // TriCore pseudo instructions format
 class Pseudo<dag outs, dag ins, string asmstr, list<dag> pattern>
-   : InstTriCore<outs, ins, asmstr, pattern> {
+   : I<outs, ins, asmstr, pattern> {
   let isPseudo = 1;
 }
 
@@ -51,7 +51,7 @@ class Pseudo<dag outs, dag ins, string asmstr, list<dag> pattern>
 // Generic 16-bit Instruction Format
 //===----------------------------------------------------------------------===//
 class T16<dag outs, dag ins, string asmstr, list<dag> pattern>
-    : InstTriCore<outs, ins, asmstr, pattern> {
+    : I<outs, ins, asmstr, pattern> {
   field bits<16> Inst;
   let Size = 2;
   field bits<16> SoftFail = 0;
@@ -61,7 +61,7 @@ class T16<dag outs, dag ins, string asmstr, list<dag> pattern>
 // Generic 32-bit Instruction Format
 //===----------------------------------------------------------------------===//
 class T32<dag outs, dag ins, string asmstr, list<dag> pattern>
-    : InstTriCore<outs, ins, asmstr, pattern> {
+    : I<outs, ins, asmstr, pattern> {
   field bits<32> Inst;
   let Size = 4;
   field bits<32> SoftFail = 0;
@@ -569,23 +569,33 @@ class RLC<bits<8> op1, dag outs, dag ins, string asmstr,
 //===----------------------------------------------------------------------===//
 // 32-bit RR Instruction Format: <d|op2|-|n|s2|s1|op1>
 //===----------------------------------------------------------------------===//
-class RR<bits<8> op1, bits<8> op2, dag outs, dag ins, string asmstr,
+class RRBase<bits<8> op1, bits<8> op2, dag outs, dag ins, string asmstr,
                  list<dag> pattern> : T32<outs, ins, asmstr, pattern> {
 
   bits<4> d;
-  bits<2> n;
   bits<4> s2;
   bits<4> s1;
 
   let Inst{31-28} = d;
   let Inst{27-20} = op2;
   let Inst{19-18} = 0;
-  let Inst{17-16} = n;
   let Inst{15-12} = s2;
   let Inst{11-8} = s1;
   let Inst{7-0} = op1;
   let DecoderMethod = "DecodeRRInstruction";
 }
+
+class RR<bits<8> op1, bits<8> op2, dag outs, dag ins, string asmstr,
+                 list<dag> pattern>: RRBase<op1, op2, outs, ins, asmstr, pattern> {
+  bits<2> n;
+  let Inst{17-16} = n;
+}
+
+class RR_n<bits<8> op1, bits<8> op2, bits<2> n, dag outs, dag ins, string asmstr,
+                 list<dag> pattern>: RRBase<op1, op2, outs, ins, asmstr, pattern> {
+  let Inst{17-16} = n;
+}
+
 
 //===----------------------------------------------------------------------===//
 // 32-bit RR1 Instruction Format: <d|op2|n|s2|s1|op1>
@@ -651,12 +661,11 @@ class RRPW<bits<8> op1, bits<2> op2, dag outs, dag ins, string asmstr,
 //===----------------------------------------------------------------------===//
 // 32-bit RRR Instruction Format: <d|s3|op2|-|n|s2|s1|op1>
 //===----------------------------------------------------------------------===//
-class RRR<bits<8> op1, bits<4> op2, dag outs, dag ins, string asmstr,
+class RRRBase<bits<8> op1, bits<4> op2, dag outs, dag ins, string asmstr,
                 list<dag> pattern> : T32<outs, ins, asmstr, pattern> {
 
   bits<4> d;
   bits<4> s3;
-  bits<2> n;
   bits<4> s2;
   bits<4> s1;
 
@@ -664,11 +673,24 @@ class RRR<bits<8> op1, bits<4> op2, dag outs, dag ins, string asmstr,
   let Inst{27-24} = s3;
   let Inst{23-20} = op2;
   let Inst{19-18} = 0;
-  let Inst{17-16} = n;
   let Inst{15-12} = s2;
   let Inst{11-8} = s1;
   let Inst{7-0} = op1;
   let DecoderMethod = "DecodeRRRInstruction";
+}
+
+class RRR<bits<8> op1, bits<4> op2, dag outs, dag ins, string asmstr,
+                list<dag> pattern> : RRRBase<op1, op2, outs, ins, asmstr, pattern> {
+
+  bits<2> n;
+
+  let Inst{17-16} = n;
+}
+
+class RRR_n<bits<8> op1, bits<4> op2, bits<2> n, dag outs, dag ins, string asmstr,
+                list<dag> pattern> : RRRBase<op1, op2, outs, ins, asmstr, pattern> {
+
+  let Inst{17-16} = n;
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/TriCore/TriCoreInstrInfo.td
+++ b/llvm/lib/Target/TriCore/TriCoreInstrInfo.td
@@ -815,6 +815,12 @@ multiclass mI_U_RR_Eab<bits<8> op1, bits<8> op2, bits<8> op3, bits<8> op4,
   def _U_rr # posfix : IRR_dab<op3, op4, asmstr # ".u", RE>;
 }
 
+multiclass mI_U_RR_Eab_n<bits<8> op1, bits<8> op2, bits<8> op3, bits<8> op4, bits<2> n,
+                string asmstr, string posfix = "", RegisterClass RC1=RD, RegisterClass RC2=RD> {
+  def _rr   # posfix : IRR_dab_n<op1, op2, n, asmstr, RE, RC1, RC2>;
+  def _U_rr # posfix : IRR_dab_n<op3, op4, n, asmstr # ".u", RE, RC1, RC2>;
+}
+
 multiclass mIU_RR_Eab<bits<8> op1, bits<8> op2, bits<8> op3, bits<8> op4,
                 string asmstr, string posfix = ""> {
   def _rr  # posfix : IRR_dab<op1, op2, asmstr, RE>;
@@ -831,7 +837,9 @@ defm _B: mIU_RR_Eab <oprefix, opb, oprefix, opbu, asmstr # ".b", posfix>;
 defm _H: mIU_RR_Eab <oprefix, oph, oprefix, ophu, asmstr # ".h", posfix>;
 }
 
-defm DIV     : mI_U_RR_Eab<0x4B, 0x20, 0x4B, 0x21, "div">, Requires<[HasV160_UP]>;
+defm DIV     : mI_U_RR_Eab_n<0x4B, 0x20, 0x4B, 0x21, 0x1, "div">, Requires<[HasV160_UP]>;
+defm DIV64     : mI_U_RR_Eab_n<0x4B, 0x20, 0x4B, 0x21, 0x2, "div64", "", RE, RE>, Requires<[HasV180_UP]>;
+defm REM64     : mI_U_RR_Eab_n<0x4B, 0x34, 0x4B, 0x35, 0x2, "rem64", "", RE, RE>, Requires<[HasV180_UP]>;
 
 defm DVINIT : mI_DVINIT_<0x4F, 0x00, 0x01, 0x04, 0x05, 0x02, 0x03, "dvinit", "_v110">, NsRequires<[HasV110]>;
 defm DVINIT : mI_DVINIT_<0x4B, 0x1A, 0x0A, 0x5A, 0x4A, 0x3A, 0x2A, "dvinit">, Requires<[HasV120_UP]>;

--- a/llvm/lib/Target/TriCore/TriCoreInstrInfo.td
+++ b/llvm/lib/Target/TriCore/TriCoreInstrInfo.td
@@ -288,6 +288,10 @@ class IRR_a<bits<8> op1, bits<8> op2, string asmstr, RegisterClass cd=RD, Regist
     : RR<op1, op2, (outs cd:$d), (ins c1:$s1),
       asmstr # " $d, $s1", []>;
 
+class IRR_a_n<bits<8> op1, bits<8> op2, bits<2> n, string asmstr, RegisterClass cd=RD, RegisterClass c1=RD>
+    : RR_n<op1, op2, n, (outs cd:$d), (ins c1:$s1),
+      asmstr # " $d, $s1", []>;
+
 /// op R[c], R[b]
 class IRR_b<bits<8> op1, bits<8> op2, string asmstr, RegisterClass cd=RD, RegisterClass c2=RD>
     : RR<op1, op2, (outs cd:$d), (ins c2:$s1, c2:$s2),
@@ -298,9 +302,17 @@ class IRR_2<bits<8> op1, bits<8> op2, string asmstr
           , RegisterClass cd=RD, RegisterClass c1=RD, RegisterClass c2=RD>
     : RR<op1, op2, (outs cd:$d), (ins c1:$s1, c2:$s2), asmstr, []>;
 
+class IRR_2_n<bits<8> op1, bits<8> op2, bits<2> n, string asmstr
+          , RegisterClass cd=RD, RegisterClass c1=RD, RegisterClass c2=RD>
+    : RR_n<op1, op2, n, (outs cd:$d), (ins c1:$s1, c2:$s2), asmstr, []>;
+
 class IRR_dab<bits<8> op1, bits<8> op2, string asmstr,
               RegisterClass RCd=RD, RegisterClass RC1=RD, RegisterClass RC2=RD>
     : IRR_2<op1, op2, asmstr # " $d, $s1, $s2", RCd, RC1, RC2>;
+
+class IRR_dab_n<bits<8> op1, bits<8> op2, bits<2> n, string asmstr,
+              RegisterClass RCd=RD, RegisterClass RC1=RD, RegisterClass RC2=RD>
+    : IRR_2_n<op1, op2, n, asmstr # " $d, $s1, $s2", RCd, RC1, RC2>;
 
 class IRR_dba<bits<8> op1, bits<8> op2, string asmstr,
               RegisterClass RCd=RD, RegisterClass RC1=RD, RegisterClass RC2=RD>
@@ -593,9 +605,18 @@ class IRRR<bits<8>op1, bits<4> op2, string asmstr,
     : RRR<op1, op2, (outs RCd:$d), (ins RC1:$s1, RC2:$s2, RC3:$s3),
           asmstr # " $d, $s3, $s1, $s2", []>;
 
+class IRRR_n<bits<8>op1, bits<4> op2, bits<2> n, string asmstr,
+           RegisterClass RCd=RD, RegisterClass RC1=RD, RegisterClass RC2=RD, RegisterClass RC3=RD>
+    : RRR_n<op1, op2, n, (outs RCd:$d), (ins RC1:$s1, RC2:$s2, RC3:$s3),
+          asmstr # " $d, $s3, $s1, $s2", []>;
+
 class IRRR_d31<bits<8>op1, bits<4> op2, string asmstr,
              RegisterClass RCd=RD, RegisterClass RC1=RD, RegisterClass RC2=RD, RegisterClass RC3=RD>
     : RRR<op1, op2, (outs RCd:$d), (ins RC1:$s1, RC2:$s2, RC3:$s3), asmstr # " $d, $s3, $s1", []>;
+
+class IRRR_d31_n<bits<8>op1, bits<4> op2, bits<2> n, string asmstr,
+             RegisterClass RCd=RD, RegisterClass RC1=RD, RegisterClass RC2=RD, RegisterClass RC3=RD>
+    : RRR_n<op1, op2, n, (outs RCd:$d), (ins RC1:$s1, RC2:$s2, RC3:$s3), asmstr # " $d, $s3, $s1", []>;
 
 class IRRR_d32<bits<8>op1, bits<4> op2, string asmstr,
               RegisterClass RCd=RD, RegisterClass RC1=RD, RegisterClass RC2=RD, RegisterClass RC3=RD>
@@ -1846,30 +1867,62 @@ defm XOR_LT_U : mIRR_RC<0x0B, 0x32, 0x8B, 0x32, "xor.lt.u">;
 
 /// FPU Instructions
 
-def MADD_F_rrr : IRRR<0x6B, 0x06, "madd.f">, Requires<[HasV130_UP]>;
-def MSUB_F_rrr : IRRR<0x6B, 0x07, "msub.f">, Requires<[HasV130_UP]>;
-def ADD_F_rrr : IRRR_d31<0x6B, 0x02, "add.f">, Requires<[HasV130_UP]>;
-def SUB_F_rrr : IRRR_d31<0x6B, 0x03, "sub.f">, Requires<[HasV130_UP]>;
-def MUL_F_rrr : IRR_dab<0x4B, 0x04, "mul.f">, Requires<[HasV130_UP]>;
-def DIV_F_rr  : IRR_dab<0x4B, 0x05, "div.f">, Requires<[HasV130_UP]>;
-def CMP_F_rr  : IRR_dab<0x4B, 0x00, "cmp.f">, Requires<[HasV130_UP]>;
+def MADD_F_rrr : IRRR_n<0x6B, 0x06, 0x1, "madd.f">, Requires<[HasV130_UP]>;
+def MSUB_F_rrr : IRRR_n<0x6B, 0x07, 0x1, "msub.f">, Requires<[HasV130_UP]>;
+def MADD_DF_rrr : IRRR_n<0x6B, 0x06, 0x2, "madd.df", RE, RE, RE, RE>, Requires<[HasV180_UP]>;
+def MSUB_DF_rrr : IRRR_n<0x6B, 0x07, 0x2, "msub.df", RE, RE, RE, RE>, Requires<[HasV180_UP]>;
+def ADD_F_rrr : IRRR_d31_n<0x6B, 0x02, 0x1, "add.f">, Requires<[HasV130_UP]>;
+def ADD_DF_rrr : IRRR_d31_n<0x6B, 0x02, 0x2, "add.df", RE, RE, RE, RE>, Requires<[HasV180_UP]>;
+def SUB_F_rrr : IRRR_d31_n<0x6B, 0x03, 0x1, "sub.f">, Requires<[HasV130_UP]>;
+def SUB_DF_rrr : IRRR_d31_n<0x6B, 0x03, 0x2, "sub.df", RE, RE, RE, RE>, Requires<[HasV180_UP]>;
+def MUL_F_rrr : IRR_dab_n<0x4B, 0x04, 0x01, "mul.f">, Requires<[HasV130_UP]>;
+def MUL_DF_rrr : IRR_dab_n<0x4B, 0x04, 0x02, "mul.df", RE, RE, RE>, Requires<[HasV180_UP]>;
+def DIV_F_rr  : IRR_dab_n<0x4B, 0x05, 0x01, "div.f">, Requires<[HasV130_UP]>;
+def DIV_DF_rr  : IRR_dab_n<0x4B, 0x05, 0x02, "div.df", RE, RE, RE>, Requires<[HasV180_UP]>;
+def CMP_F_rr  : IRR_dab_n<0x4B, 0x00, 0x01, "cmp.f">, Requires<[HasV130_UP]>;
+def CMP_DF_rr  : IRR_dab_n<0x4B, 0x00, 0x02, "cmp.df", RD, RE, RE>, Requires<[HasV180_UP]>;
+def MIN_F_rr  : IRR_dab_n<0x4B, 0x33, 0x01, "min.f">, Requires<[HasV180_UP]>;
+def MIN_DF_rr  : IRR_dab_n<0x4B, 0x33, 0x02, "min.df", RE, RE, RE>, Requires<[HasV180_UP]>;
+def MAX_F_rr  : IRR_dab_n<0x4B, 0x32, 0x01, "max.f">, Requires<[HasV180_UP]>;
+def MAX_DF_rr  : IRR_dab_n<0x4B, 0x32, 0x02, "max.df", RE, RE, RE>, Requires<[HasV180_UP]>;
 
-def FTOI_rr   : IRR_a<0x4B, 0x10, "ftoi">, Requires<[HasV130_UP]>;
-def FTOIZ_rr  : IRR_a<0x4B, 0x13, "ftoiz">, Requires<[HasV131_UP]>;
+def FTOI_rr   : IRR_a_n<0x4B, 0x10, 0x01, "ftoi">, Requires<[HasV130_UP]>;
+def DFTOI_rr   : IRR_a_n<0x4B, 0x10, 0x02, "dftoi", RD, RE>, Requires<[HasV180_UP]>;
+def FTOIZ_rr  : IRR_a_n<0x4B, 0x13, 0x01, "ftoiz">, Requires<[HasV131_UP]>;
+def DFTOIZ_rr   : IRR_a_n<0x4B, 0x13, 0x02, "dftoiz", RD, RE>, Requires<[HasV180_UP]>;
+def FTOIN_rr   : IRR_a_n<0x4B, 0x37, 0x01, "ftoin">, Requires<[HasV180_UP]>;
+def DFTOIN_rr   : IRR_a_n<0x4B, 0x37, 0x02, "dftoin", RD, RE>, Requires<[HasV180_UP]>;
+def DFTOL_rr   : IRR_a_n<0x4B, 0x1A, 0x02, "dftol", RE, RE>, Requires<[HasV180_UP]>;
+def DFTOLZ_rr   : IRR_a_n<0x4B, 0x1B, 0x02, "dftolz", RE, RE>, Requires<[HasV180_UP]>;
+def DFTOUL_rr   : IRR_a_n<0x4B, 0x1E, 0x02, "dftoul", RE, RE>, Requires<[HasV180_UP]>;
+def DFTOULZ_rr   : IRR_a_n<0x4B, 0x1F, 0x02, "dftoulz", RE, RE>, Requires<[HasV180_UP]>;
+def ABS_F_rr   : IRR_a_n<0x4B, 0x30, 0x01, "abs.f">, Requires<[HasV180_UP]>;
+def ABS_DF_rr   : IRR_a_n<0x4B, 0x30, 0x02, "abs.df", RE, RE>, Requires<[HasV180_UP]>;
+def NEG_F_rr   : IRR_a_n<0x4B, 0x31, 0x01, "neg.f">, Requires<[HasV180_UP]>;
+def NEG_DF_rr   : IRR_a_n<0x4B, 0x31, 0x02, "neg.df", RE, RE>, Requires<[HasV180_UP]>;
 
 def FTOQ31_rr : IRR_dab<0x4B, 0x11, "ftoq31">, Requires<[HasV130_UP]>;
 def FTOQ31Z_rr: IRR_dab<0x4B, 0x18, "ftoq31z">, Requires<[HasV131_UP]>;
 
-def FTOU_rr   : IRR_a<0x4B, 0x12, "ftou">, Requires<[HasV130_UP]>;
-def FTOUZ_rr  : IRR_a<0x4B, 0x17, "ftouz">, Requires<[HasV131_UP]>;
+def FTOU_rr   : IRR_a_n<0x4B, 0x12, 0x01, "ftou">, Requires<[HasV130_UP]>;
+def DFTOU_rr   : IRR_a_n<0x4B, 0x12, 0x02, "dftou", RD, RE>, Requires<[HasV180_UP]>;
+def FTOUZ_rr  : IRR_a_n<0x4B, 0x17, 0x01, "ftouz">, Requires<[HasV131_UP]>;
+def DFTOUZ_rr   : IRR_a_n<0x4B, 0x17, 0x02, "dftouz", RD, RE>, Requires<[HasV180_UP]>;
 
 def FTOHP_rr  : IRR_a<0x4B, 0x25, "ftohp">, Requires<[HasV162_UP]>;
 
 def HPTOF_rr  : IRR_a<0x4B, 0x24, "hptof">, Requires<[HasV162_UP]>;
-def ITOF_rr   : IRR_a<0x4B, 0x14, "itof">, Requires<[HasV130_UP]>;
+def ITOF_rr   : IRR_a_n<0x4B, 0x14, 0x01, "itof">, Requires<[HasV130_UP]>;
+def ITODF_rr   : IRR_a_n<0x4B, 0x14, 0x02, "itodf", RE, RD>, Requires<[HasV180_UP]>;
 
 def Q31TOF_rr  : IRR_dab<0x4B, 0x15, "q31tof">, Requires<[HasV130_UP]>;
-def QSEED_F_rr : IRR_a<0x4B, 0x19, "qseed.f">, Requires<[HasV130_UP]>;
+def QSEED_F_rr : IRR_a_n<0x4B, 0x19, 0x01, "qseed.f">, Requires<[HasV130_UP]>;
+def QSEED_DF_rr : IRR_a_n<0x4B, 0x19, 0x02, "qseed.df", RE, RE>, Requires<[HasV180_UP]>;
 
 def UPDFL_rr   : IRR_R1<0x4B, 0x0C, "updfl">, Requires<[HasV130_UP]>;
-def UTOF_rr    : IRR_a<0x4B, 0x16, "utof">, Requires<[HasV130_UP]>;
+def UTOF_rr    : IRR_a_n<0x4B, 0x16, 0x01, "utof">, Requires<[HasV130_UP]>;
+def UTODF_rr   : IRR_a_n<0x4B, 0x16, 0x02, "utodf", RE, RD>, Requires<[HasV180_UP]>;
+def LTODF_rr   : IRR_a_n<0x4B, 0x26, 0x02, "ltodf", RE, RE>, Requires<[HasV180_UP]>;
+def ULTODF_rr   : IRR_a_n<0x4B, 0x27, 0x02, "ultodf", RE, RE>, Requires<[HasV180_UP]>;
+def DFTOF_rr   : IRR_a_n<0x4B, 0x28, 0x02, "dftof", RD, RE>, Requires<[HasV180_UP]>;
+def FTODF_rr   : IRR_a_n<0x4B, 0x29, 0x02, "ftodf", RE, RD>, Requires<[HasV180_UP]>;


### PR DESCRIPTION
Add tricore tc1.8 instructions:
```
add.df
sub.df
madd.df
msub.df
mul.df
div.df
cmp.df
max.df
min.df
min.f
max.f
dftoi
dftoiz
dftoin
ftoin
dftou
dftouz
dftol
dftoul
dftoulz
abs.f
abs.df
dftolz
neg.df
neg.f
qseed.df
itodf
utodf
ltodf
ultodf
dftof
ftodf
div64
div64.u
rem64
rem64.u
```

A major change in tc18 instruction encoding is:
The n field can indicate mnemonics for instruction variant with 64bit register operand. 
For example `6b 00 21 00` is  `add.f %d0,%d0,%d0`.
`6b 00 22 00` is `add.df %e0,%e0,%e0`