### PR TITLE
Fix wrong version of Tricore instructions and wrong instruction encoding

### DIFF
--- a/llvm/lib/Target/TriCore/TriCore.td
+++ b/llvm/lib/Target/TriCore/TriCore.td
@@ -70,7 +70,7 @@ def HasV161_UP  : Predicate<"HasV161Ops() || HasV162Ops() || HasV180Ops()">
 				, AssemblerPredicate<(any_of HasV161Ops, HasV162Ops, HasV180Ops), "v161up">;
 def HasV162_UP  : Predicate<"HasV162Ops() || HasV180Ops()">
 				, AssemblerPredicate<(any_of HasV162Ops, HasV180Ops), "v162up">;
-def HasV180_UP  : Predicate<"HasV162Ops()">
+def HasV180_UP  : Predicate<"HasV180Ops()">
 				, AssemblerPredicate<(any_of HasV180Ops), "v180up">;
 
 def HasV120_DN : Predicate<"HasV120Ops() || HasV110Ops()">,
@@ -86,7 +86,7 @@ def HasV161_DN : Predicate<"HasV161Ops() || HasV160Ops() || HasV131Ops() || HasV
 def HasV162_DN : Predicate<"HasV162Ops() || HasV161Ops() || HasV160Ops() || HasV131Ops() || HasV130Ops() || HasV120Ops() || HasV110Ops()">,
 				AssemblerPredicate<(any_of HasV162Ops, HasV161Ops, HasV160Ops, HasV131Ops, HasV130Ops, HasV120Ops, HasV110Ops), "v162dn">;
 def HasV180_DN : Predicate<"HasV180Ops() || HasV162Ops() || HasV161Ops() || HasV160Ops() || HasV131Ops() || HasV130Ops() || HasV120Ops() || HasV110Ops()">,
-				AssemblerPredicate<(any_of HasV180Ops, HasV162Ops, HasV161Ops, HasV160Ops, HasV131Ops, HasV130Ops, HasV120Ops, HasV110Ops), "v162dn">;
+				AssemblerPredicate<(any_of HasV180Ops, HasV162Ops, HasV161Ops, HasV160Ops, HasV131Ops, HasV130Ops, HasV120Ops, HasV110Ops), "v180dn">;
 
 
 class Architecture<string fname, string aname, list<SubtargetFeature> features = []>
@@ -104,7 +104,7 @@ def TRICORE_V1_3_1  : Architecture<"tricore-V1.3.1",  "TRICOREv131", [HasV131Ops
 def TRICORE_V1_6    : Architecture<"tricore-V1.6",    "TRICOREv160", [HasV160Ops]>;
 def TRICORE_V1_6_1  : Architecture<"tricore-V1.6.1",  "TRICOREv161", [HasV161Ops]>;
 def TRICORE_V1_6_2  : Architecture<"tricore-V1.6.2",  "TRICOREv162", [HasV162Ops]>;
-def TRICORE_V1_8_0  : Architecture<"tricore-V1.8.0",  "TRICOREv162", [HasV180Ops]>;
+def TRICORE_V1_8_0  : Architecture<"tricore-V1.8.0",  "TRICOREv180", [HasV180Ops]>;
 def TRICORE_PCP     : Architecture<"tricore-PCP",     "TRICOREpcp">;
 def TRICORE_PCP2    : Architecture<"tricore-PCP2",    "TRICOREpcp2">;
 

--- a/llvm/lib/Target/TriCore/TriCoreInstrInfo.td
+++ b/llvm/lib/Target/TriCore/TriCoreInstrInfo.td
@@ -378,6 +378,7 @@ class NsRequires<list<Predicate> Ps> : Requires<Ps> {
                                   !eq(HasV160, !head(Ps)): "v160",
                                   !eq(HasV161, !head(Ps)): "v161",
                                   !eq(HasV162, !head(Ps)): "v162",
+                                  !eq(HasV180, !head(Ps)): "v180",
                                   true: "");
 }
 
@@ -539,7 +540,6 @@ defm ANDN     : mIRR_RC<0x0F, 0x0E, 0x8F, 0x0E, "andn">;
 
 /// BISR
 def BISR_rc : IRC_C<0xAD, 0x00, "bisr">;
-def BISR_rc_v161 : IRC_C<0xAD, 0x01, "bisr">, NsRequires<[HasV161]>;
 
 def BISR_sc_v110 : ISC_C<0xC0, "bisr">, NsRequires<[HasV110]>;
 def BISR_sc : ISC_C<0xE0, "bisr">, Requires<[HasV120_UP]>;
@@ -742,10 +742,10 @@ defm CMPSWAP_W : mIBO_Ea<0x49, 0x23, 0x69, 0x03,
                          0x49, 0x13, "cmpswap.w">
                , Requires<[HasV161_UP]>;
 
-def CRC32_B_rr  : IRR_dba<0x4B, 0x06, "crc32.b">, Requires<[HasV162]>;
-def CRC32B_W_rr : IRR_dba<0x4B, 0x03, "crc32b.w">, Requires<[HasV162]>;
-def CRC32L_W_rr : IRR_dba<0x4B, 0x07, "crc32l.w">, Requires<[HasV162]>;
-def CRCN_rrr    : IRRR<0x6B, 0x01, "crcn">, Requires<[HasV162]>;
+def CRC32_B_rr  : IRR_dba<0x4B, 0x06, "crc32.b">, Requires<[HasV162_UP]>;
+def CRC32B_W_rr : IRR_dba<0x4B, 0x03, "crc32b.w">, Requires<[HasV162_UP]>;
+def CRC32L_W_rr : IRR_dba<0x4B, 0x07, "crc32l.w">, Requires<[HasV162_UP]>;
+def CRCN_rrr    : IRRR<0x6B, 0x01, "crcn">, Requires<[HasV162_UP]>;
 
 def CSUB_rrr    : IRRR<0x2B, 0x02, "csub">;
 def CSUBN_rrr   : IRRR<0x2B, 0x03, "csubn">;
@@ -1547,9 +1547,7 @@ multiclass mISR_1<bits<8> sr1op1, bits<4> sr1op2, bits<8> sr2op1, bits<4> sr2op2
 defm NOR : mIRR_RC<0x0F, 0x0B, 0x8F, 0x0B, "nor">;
 def NOR_T : IBIT<0x87, 0x02, "nor.t">;
 
-defm NOR : mISR_1<0x46, 0x00, 0x36, 0x00, "nor">;
-
-def NOT_sr_v162 : ISR_1<0x46, 0x00, "not">, NsRequires<[HasV162]>;
+def NOT_sr : ISR_1<0x46, 0x00, "not">, Requires<[HasV120_UP]>;
 
 
 defm OR : mIRR_RC<0x0F, 0x0A, 0x8F, 0x0A, "or", RD, RD, u9imm>;
@@ -1587,7 +1585,7 @@ multiclass mISYS_0<bits<8> sys1op1, bits<6> sys1op2, bits<8> sys2op1, bits<6> sy
 def PARITY_rr : IRR_a<0x4B, 0x02, "parity">, Requires<[HasV120_UP]>;
 def PARITY_rr_v110 : IRR_a<0x4B, 0x08, "parity">, NsRequires<[HasV110]>;
 
-def POPCNT_W_rr : IRR_a<0x4B, 0x22, "popcnt.w">, NsRequires<[HasV162]>;
+def POPCNT_W_rr : IRR_a<0x4B, 0x22, "popcnt.w">, NsRequires<[HasV162_UP]>;
 
 def RESTORE_sys : ISYS_1<0x0D, 0x0E, "restore">, Requires<[HasV160_UP]>;
 
@@ -1664,7 +1662,7 @@ defm SHA_B : mIRR_RC<0x0F, 0x21, 0x8F, 0x21, "sha.b">, NsRequires<[HasV110]>;
 defm SHA_H : mIRR_RC<0x0F, 0x41, 0x8F, 0x41, "sha.h">;
 defm SHAS : mIRR_RC<0x0F, 0x02, 0x8F, 0x02, "shas">;
 
-def SHUFFLE_rc : IRC<0x8F, 0x07, "shuffle">, Requires<[HasV162]>;
+def SHUFFLE_rc : IRC<0x8F, 0x07, "shuffle">, Requires<[HasV162_UP]>;
 
 // A[b], off10, A[a] (BO)(Base + Short Offset Addressing Mode)
 class IBO_bso_st<bits<8> op1, bits<6> op2, string asmstr, RegisterClass RC> 


### PR DESCRIPTION
## Fix wrong version config of tricore tc16 instructions:
Following instructions should be `HasV162_UP` because there also exist in tc18
1. crc32.b
![image](https://github.com/user-attachments/assets/09170c82-22fe-475f-8cb0-90120c90e816)
2. crc32b.w
![image](https://github.com/user-attachments/assets/c7dab4dd-73cb-4b4c-a4e2-d3bff4b46d85)
3. crc32l.w
![image](https://github.com/user-attachments/assets/4f840da9-d055-4988-b027-5312398f7a0e)
4. crcn
![image](https://github.com/user-attachments/assets/781dea33-bb86-4949-8a3d-ce930d66d3aa)
5. popcnt.w
![image](https://github.com/user-attachments/assets/ad5f1b97-8f67-4c1e-9a49-2bbd64a70a28)
8. shuffle
![image](https://github.com/user-attachments/assets/f534323f-3959-4411-96cf-e9bf36cd693f)

## Clean up an invalid instruction BISR_rc_v161
By looking into the [tricore 1.6.1 instruction manual](https://www.infineon.com/dgdl/Infineon-TC2xx_Architecture_vol2-UM-v01_00-EN.pdf?fileId=5546d46269bda8df0169ca1bf33124a8). There is no `bisr` With opcode `0xAD 0x01`. There is only `0xAD 0x00`.
![image](https://github.com/user-attachments/assets/a5a7b365-98e7-4969-8485-3906f30925a2)

![image](https://github.com/user-attachments/assets/7c931aac-4121-40b3-9d5a-d4d552841897)

## Clean up `nor` and `not`
In current `next` branch, opcode `0x46` is assigned to both `not` and `nor`. It should be a bug. 
![image](https://github.com/user-attachments/assets/da0b821e-221c-41a4-8985-4698817ec72d)
`0x46` is an opcode for `not`
![image](https://github.com/user-attachments/assets/aed30034-36a6-4d43-988e-d7a983ef92d9)
On the other hand, `0x36` is not opcode of `nor`.
![image](https://github.com/user-attachments/assets/79b8193d-f9d6-4e14-ab43-72f1bcf664fa)

## Fix some typo of tricore tc1.8 naming
