### PR TITLE
Add `<cstdint>` to SmallVector.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ pythonenv*
 # automodapi puts generated documentation files here.
 /lldb/docs/python_api/
 output_tmp/
+.venv/

--- a/llvm/include/llvm/ADT/SmallVector.h
+++ b/llvm/include/llvm/ADT/SmallVector.h
@@ -26,6 +26,7 @@
 #include <iterator>
 #include <limits>
 #include <memory>
+#include <cstdint>
 #include <new>
 #include <type_traits>
 #include <utility>


### PR DESCRIPTION
Build fails as `<cstdint>` needs to be included explicitly on gcc 15+.

This has been patched upstream as well [llvm/llvm-project#101761](https://github.com/llvm/llvm-project/pull/101761)
The change to GCC https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=3a817a4a5a6d94da9127af3be9f84a74e3076ee2

Also added `.venv/` to the `.gitignore`