### PR TITLE
RISCV: Preserve dots in mnemonics for name2id() lookup

### DIFF
--- a/llvm/utils/TableGen/PrinterCapstone.cpp
+++ b/llvm/utils/TableGen/PrinterCapstone.cpp
@@ -3953,7 +3953,11 @@ void printInsnAliasEnum(CodeGenTarget const &Target,
                      getLLVMInstEnumName(Target.getName().upper(), RealInst) +
                      "\n";
 
-    bool ReplaceDotInMnemonic = Target.getName().equals_insensitive("PPC") ? false : true;
+    bool ReplaceDotInMnemonic = true;
+    if (Target.getName().equals_insensitive("PPC"))
+	    ReplaceDotInMnemonic = false;
+    else if (Target.getName().equals_insensitive("RISCV"))
+	    ReplaceDotInMnemonic = false;
     AliasMnemMap << "\t{ " + NormAliasMnem + ", \"" +
                         getNormalMnemonic(Target.getName(), AliasMnemonic, false,
                                            ReplaceDotInMnemonic) +

--- a/llvm/utils/TableGen/PrinterCapstone.cpp
+++ b/llvm/utils/TableGen/PrinterCapstone.cpp
@@ -3953,11 +3953,8 @@ void printInsnAliasEnum(CodeGenTarget const &Target,
                      getLLVMInstEnumName(Target.getName().upper(), RealInst) +
                      "\n";
 
-    bool ReplaceDotInMnemonic = true;
-    if (Target.getName().equals_insensitive("PPC"))
-	    ReplaceDotInMnemonic = false;
-    else if (Target.getName().equals_insensitive("RISCV"))
-	    ReplaceDotInMnemonic = false;
+    bool ReplaceDotInMnemonic = !(Target.getName().equals_insensitive("PPC") ||
+                                  Target.getName().equals_insensitive("RISCV"));
     AliasMnemMap << "\t{ " + NormAliasMnem + ", \"" +
                         getNormalMnemonic(Target.getName(), AliasMnemonic, false,
                                            ReplaceDotInMnemonic) +


### PR DESCRIPTION
This is needed for mnemonics that contain a dot when `map_set_alias_id()` calls `name2id()` for matching. Aliases with a dot in their name would not match the mnemonic from RISCVGenCSAliasMnemMap.inc (e.g., `cv.mulhhu != cv_mulhhu`).

Capstone issue: capstone-engine/capstone#2861